### PR TITLE
fix(exam-helper): prevent injecting home widget on login page

### DIFF
--- a/docs/pages/home.md
+++ b/docs/pages/home.md
@@ -1,21 +1,81 @@
 # Trang Chủ / Dashboard - Page Structure
 
-> Tài liệu mô tả cấu trúc trang chủ (Dashboard) cổng thông tin sinh viên HaUI.
+> Tài liệu mô tả cấu trúc trang chủ (Dashboard) và các trạng thái hiển thị của đường dẫn `/` trên cổng thông tin sinh viên HaUI (`sv.haui.edu.vn`).
 
 ---
 
-## 1. Tổng quan
+## 1. Tổng quan & Trạng thái đường dẫn (`/`)
 
-- **URL:** `/` hoặc `https://sv.haui.edu.vn/`
+Đường dẫn gốc `/` (hoặc `https://sv.haui.edu.vn/`) có **2 trạng thái giao diện hoàn toàn khác nhau** tùy thuộc vào phiên đăng nhập của người dùng:
+
+| Trạng thái                         | Điều kiện                  | Container chính        | Dấu hiệu nhận biết                                                                                                                     |
+| :--------------------------------- | :------------------------- | :--------------------- | :------------------------------------------------------------------------------------------------------------------------------------- |
+| **A. Đã đăng nhập** (Dashboard)    | Đã có Session hợp lệ       | `div.cttsv-dashboard`  | Có topbar với tên SV (`.be-user-nav .user-name`), sidebar menu (`.be-left-sidebar`), `div.cttsv-action-grid`.                          |
+| **B. Chưa đăng nhập** (Login View) | Chưa đăng nhập / Hết phiên | `div.splash-container` | Không có sidebar/tên SV. Xuất hiện form đăng nhập với `#ctl00_inpUserName`, `#ctl00_inpPassword`, `#ctl00_butLogin`, Google reCAPTCHA. |
+
+> [!WARNING]
+> **Lưu ý quan trọng khi phát triển Feature (Tránh chèn nhầm UI):**
+> Do cả 2 trạng thái đều có cùng URL pathname là `/` và đều có thẻ cha bao bọc là `div.be-content` / `div.main-content`, các feature hiển thị trên trang chủ (như `exam-helper`, `home-shortcuts`) **tuyệt đối không** chỉ dựa vào URL `/` hoặc observe `div.be-content` rồi fallback `prepend`/`appendChild`.
+>
+> **Bắt buộc** phải kiểm tra sự tồn tại của các container đặc trưng của Dashboard như `div.cttsv-dashboard`, `div.cttsv-action-grid`, `section.cttsv-overview-section` hoặc `.be-user-nav .user-name` trước khi chèn bất kỳ UI nào.
+
+---
+
+## 2. Trạng thái Chưa đăng nhập (Login View - `div.splash-container`)
+
+Khi người dùng chưa đăng nhập, server ASP.NET trả về giao diện form đăng nhập trực tiếp ngay tại URL `/`:
+
+```
+div.be-content
+└─ div.main-content.container-fluid > form#frmMain name="frmMain"
+   ├─ div > input#__VIEWSTATE
+   ├─ div > input#__VIEWSTATEGENERATOR
+   └─ div.splash-container > div.panel.panel-default.panel-border-color.panel-border-color-primary
+      ├─ div.panel-heading.panel-heading-divider
+      │  ├─ img.logo-img src=".../img/logo-haui-size.png" alt="logo"
+      │  └─ span.splash-description
+      │     ├─ h4 "Trường Đại học Công nghiệp Hà Nội"
+      │     └─ h5 "Sinh viên đăng nhập"
+      ├─ div.panel-body
+      │  ├─ div.form-group > input#ctl00_inpUserName.form-control name="ctl00$inpUserName"
+      │  ├─ div.form-group > input#ctl00_inpPassword.form-control name="ctl00$inpPassword"
+      │  ├─ div.form-group > div.g-recaptcha
+      │  │  └─ iframe (Google reCAPTCHA v2)
+      │  ├─ div.form-group.login-submit > input#ctl00_butLogin.btn.btn-primary.btn-xl name="ctl00$butLogin"
+      │  ├─ div.splash-footer > a "Quên mật khẩu" href="/help?repass=1"
+      │  └─ div.splash-footer > a "Xem hướng dẫn" href="https://sv.dhcnhn.vn/files/HDSV_QuenMK.pdf"
+      └─ div.panel-body > div.form-group.login-submit.text-center
+         └─ a href="https://one.haui.edu.vn/loginapi/sv" (Đăng nhập Microsoft HaUI O365)
+```
+
+### Các Selector đặc trưng của Login View
+
+| Thành phần             | Selector                  | Mục đích                                      |
+| :--------------------- | :------------------------ | :-------------------------------------------- |
+| **Login Container**    | `div.splash-container`    | Khối bao bọc toàn bộ form đăng nhập           |
+| **Tên đăng nhập**      | `input#ctl00_inpUserName` | Ô nhập mã SV / Email                          |
+| **Mật khẩu**           | `input#ctl00_inpPassword` | Ô nhập mật khẩu                               |
+| **Google reCAPTCHA**   | `div.g-recaptcha`         | Widget xác thực người dùng của Google         |
+| **Nút Đăng nhập**      | `input#ctl00_butLogin`    | Nút submit form đăng nhập                     |
+| **Nút Đăng nhập O365** | `a[href*="loginapi/sv"]`  | Đăng nhập tài khoản Microsoft HaUI Office 365 |
+| **Quên mật khẩu**      | `a[href*="repass=1"]`     | Link khôi phục mật khẩu                       |
+
+---
+
+## 3. Trạng thái Đã đăng nhập (Dashboard View - `div.cttsv-dashboard`)
+
+Khi đã xác thực thành công, `/` hiển thị đầy đủ giao diện Dashboard sinh viên.
+
+- **URL:** `/` hoặc `https://sv.haui.edu.vn/` (hoặc `/home`)
 - **Mục đích:** Hiển thị tổng quan thông tin cá nhân sinh viên, chỉ số thống kê nhanh (thông báo mới, công nợ, tiến độ học tập), chi tiết học tập & tài chính, cùng danh sách lối tắt điều hướng đến toàn bộ các tính năng chính của hệ thống.
 - **Selector chính:** `div.cttsv-dashboard`
 - **Form bao bọc:** `form#frmMain` (Chứa `__VIEWSTATE`, `__VIEWSTATEGENERATOR`)
 
 ---
 
-## 2. Cấu trúc chi tiết
+## 4. Cấu trúc chi tiết Dashboard (Authenticated)
 
-### 2.1. Hero Section - Thông tin cá nhân & Thao tác nhanh
+### 4.1. Hero Section - Thông tin cá nhân & Thao tác nhanh
 
 Khu vực banner chào đón đầu trang chứa ảnh đại diện, thông tin cơ bản của sinh viên và các nút hành động nhanh.
 
@@ -36,7 +96,7 @@ Khu vực banner chào đón đầu trang chứa ảnh đại diện, thông tin
 
 ---
 
-### 2.2. KPI Grid - Chỉ số thống kê nhanh
+### 4.2. KPI Grid - Chỉ số thống kê nhanh
 
 Khu vực 3 thẻ thống kê các chỉ số quan trọng (Thông báo mới, Công nợ cần xử lý, Tiến độ học tập).
 
@@ -56,7 +116,7 @@ _Cấu trúc chi tiết bên trong mỗi thẻ:_
 
 ---
 
-### 2.3. Tổng quan cá nhân (Overview Section)
+### 4.3. Tổng quan cá nhân (Overview Section)
 
 Khối hiển thị 3 bảng tổng quan: Hồ sơ sinh viên, Học tập và Tài chính.
 
@@ -99,7 +159,7 @@ Danh sách thông tin cá nhân và cố vấn học tập theo định dạng k
 
 ---
 
-### 2.4. Chức năng sinh viên (Action Grid)
+### 4.4. Chức năng sinh viên (Action Grid)
 
 Khu vực thẻ liên kết điều hướng nhanh đến các tính năng nghiệp vụ của sinh viên.
 
@@ -125,7 +185,7 @@ _Cấu trúc bên trong mỗi thẻ `a.cttsv-action-card`:_
 
 ---
 
-### 2.5. Khối Thông tin & Liên kết nhanh (Info Grid)
+### 4.5. Khối Thông tin & Liên kết nhanh (Info Grid)
 
 Khu vực hiển thị danh sách nhiệm vụ cần hoàn thành và các liên kết tra cứu học tập chuyên sâu.
 

--- a/src/features/exam-helper/__tests__/home-exam-widget.test.ts
+++ b/src/features/exam-helper/__tests__/home-exam-widget.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { getUpcomingExamsList } from '../ui/home-exam-widget';
+import { getUpcomingExamsList, mountHomeExamWidget } from '../ui/home-exam-widget';
 import { ExamPlanEntry, ExamScheduleEntry } from '../types';
 
 describe('getUpcomingExamsList', () => {
@@ -92,5 +92,115 @@ describe('getUpcomingExamsList', () => {
         ];
 
         expect(getUpcomingExamsList([], pastPlan, fixedNow)).toEqual([]);
+    });
+});
+
+describe('mountHomeExamWidget', () => {
+    it('returns false and does not mount when on unauthenticated login page', () => {
+        const mockRoot = {
+            querySelector: (selector: string) => {
+                if (selector === 'div.splash-container') return {} as HTMLElement;
+                return null;
+            },
+        } as unknown as HTMLElement;
+
+        const widget = { isConnected: false } as HTMLElement;
+        expect(mountHomeExamWidget(widget, mockRoot)).toBe(false);
+    });
+
+    it('returns false when dashboard container lacks target section', () => {
+        const mockDashboard = {
+            querySelector: () => null,
+        } as unknown as HTMLElement;
+
+        const mockRoot = {
+            querySelector: (selector: string) => {
+                if (selector === 'div.cttsv-dashboard') return mockDashboard;
+                return null;
+            },
+        } as unknown as HTMLElement;
+
+        const widget = { isConnected: false } as HTMLElement;
+        expect(mountHomeExamWidget(widget, mockRoot)).toBe(false);
+    });
+
+    it('mounts successfully before overview section on authenticated dashboard', () => {
+        let insertedChild: unknown = null;
+        let insertedBefore: unknown = null;
+
+        const mockTarget = {} as HTMLElement;
+        const mockDashboard = {
+            querySelector: (selector: string) => {
+                if (selector === 'section.cttsv-overview-section') return mockTarget;
+                return null;
+            },
+            insertBefore: (child: unknown, before: unknown) => {
+                insertedChild = child;
+                insertedBefore = before;
+            },
+        } as unknown as HTMLElement;
+
+        const mockRoot = {
+            querySelector: (selector: string) => {
+                if (selector === 'div.cttsv-dashboard') return mockDashboard;
+                return null;
+            },
+        } as unknown as HTMLElement;
+
+        const widget = { isConnected: false } as HTMLElement;
+        const result = mountHomeExamWidget(widget, mockRoot);
+
+        expect(result).toBe(true);
+        expect(insertedChild).toBe(widget);
+        expect(insertedBefore).toBe(mockTarget);
+    });
+
+    it('mounts successfully before action grid if overview section is absent', () => {
+        let insertedChild: unknown = null;
+        let insertedBefore: unknown = null;
+
+        const mockTarget = {} as HTMLElement;
+        const mockDashboard = {
+            querySelector: (selector: string) => {
+                if (selector === 'section.cttsv-action-grid, div.cttsv-action-grid') {
+                    return mockTarget;
+                }
+                return null;
+            },
+            insertBefore: (child: unknown, before: unknown) => {
+                insertedChild = child;
+                insertedBefore = before;
+            },
+        } as unknown as HTMLElement;
+
+        const mockRoot = {
+            querySelector: (selector: string) => {
+                if (selector === 'div.cttsv-dashboard') return mockDashboard;
+                return null;
+            },
+        } as unknown as HTMLElement;
+
+        const widget = { isConnected: false } as HTMLElement;
+        const result = mountHomeExamWidget(widget, mockRoot);
+
+        expect(result).toBe(true);
+        expect(insertedChild).toBe(widget);
+        expect(insertedBefore).toBe(mockTarget);
+    });
+
+    it('avoids duplicate mounting if widget is already connected or in DOM', () => {
+        const widget = { isConnected: true } as HTMLElement;
+        const mockDashboard = {
+            querySelector: () => null,
+        } as unknown as HTMLElement;
+
+        const mockRoot = {
+            querySelector: (selector: string) => {
+                if (selector === 'div.cttsv-dashboard') return mockDashboard;
+                return null;
+            },
+        } as unknown as HTMLElement;
+
+        expect(mountHomeExamWidget(widget, mockRoot)).toBe(true);
     });
 });

--- a/src/features/exam-helper/index.ts
+++ b/src/features/exam-helper/index.ts
@@ -33,11 +33,15 @@ import {
     setDownloadBtnState,
     setUpdateBtnState,
     setStatusText,
-    ExamUIRefs,
+    type ExamUIRefs,
 } from './ui';
 import { createPlanSummaryTable, createStreamingPlanTable } from './ui/plan-table-view';
 import { enhanceScheduleTable } from './ui/schedule-enhancer';
-import { createHomeExamWidget, updateHomeExamWidget } from './ui/home-exam-widget';
+import {
+    createHomeExamWidget,
+    updateHomeExamWidget,
+    mountHomeExamWidget,
+} from './ui/home-exam-widget';
 import { getExamCountdown, detectExamSemester } from './time-utils';
 
 // ============================================
@@ -689,33 +693,16 @@ export class ExamHelperFeature extends Feature<ExportExamStorage> {
         widget.classList.add(`${this.id}-home-widget`);
 
         observeDomUntil(
-            '.be-content, div.cttsv-dashboard, div.main-content',
+            'div.cttsv-dashboard, div.cttsv-action-grid, section.cttsv-overview-section',
             () => {
-                const dashboard =
-                    document.querySelector('div.cttsv-dashboard') ||
-                    document.querySelector('.be-content') ||
-                    document.querySelector('div.main-content');
-                if (!dashboard) return false;
-
-                // Avoid injecting twice
-                if (document.querySelector(`.${this.id}-home-widget`)) return true;
-
-                // Insert right before the overview section or action grid
-                const target =
-                    dashboard.querySelector('section.cttsv-overview-section') ||
-                    dashboard.querySelector('section.cttsv-action-grid, div.cttsv-action-grid');
-
-                if (target) {
-                    dashboard.insertBefore(widget, target);
-                } else {
-                    dashboard.prepend(widget);
+                const mounted = mountHomeExamWidget(widget);
+                if (mounted) {
+                    this.log.i('Home exam widget injected');
+                    // Real-time background sync of schedule rooms/SBD right after mount
+                    syncHomeData(widget);
+                    return true;
                 }
-
-                this.log.i('Home exam widget injected');
-
-                // Real-time background sync of schedule rooms/SBD right after mount
-                syncHomeData(widget);
-                return true;
+                return false;
             },
             {
                 signal: this.abortController?.signal,

--- a/src/features/exam-helper/ui/home-exam-widget.ts
+++ b/src/features/exam-helper/ui/home-exam-widget.ts
@@ -214,3 +214,49 @@ export function updateHomeExamWidget(
         }
     }
 }
+
+/**
+ * Mounts the upcoming exams widget into the home dashboard DOM.
+ * Strictly guards against unauthenticated / login views (div.splash-container).
+ *
+ * @param widget - The widget element to mount
+ * @param root - The root document or container to search within (defaults to document)
+ * @returns boolean indicating whether the widget was successfully mounted
+ */
+export function mountHomeExamWidget(
+    widget: HTMLElement,
+    root: Document | HTMLElement = typeof document !== 'undefined' ? document : ({} as Document)
+): boolean {
+    if (!root || typeof root.querySelector !== 'function') return false;
+
+    // 1. Guard: Never mount on unauthenticated / login page
+    if (
+        root.querySelector('div.splash-container') ||
+        root.querySelector('input#ctl00_inpUserName')
+    ) {
+        return false;
+    }
+
+    // 2. Locate the main dashboard container
+    const dashboard =
+        root.querySelector('div.cttsv-dashboard') ||
+        root.querySelector('.be-content') ||
+        root.querySelector('div.main-content');
+    if (!dashboard) return false;
+
+    // 3. Avoid injecting duplicate widgets
+    if (widget.isConnected || dashboard.querySelector(`.${styles.homeExamWidget}`)) {
+        return true;
+    }
+
+    // 4. Target insertion point: overview section or action grid
+    const target =
+        dashboard.querySelector('section.cttsv-overview-section') ||
+        dashboard.querySelector('section.cttsv-action-grid, div.cttsv-action-grid');
+
+    // Strictly require a valid dashboard section to prevent injecting into unexpected views
+    if (!target) return false;
+
+    dashboard.insertBefore(widget, target);
+    return true;
+}


### PR DESCRIPTION
## 📌 Tổng quan thay đổi

Khắc phục tình trạng widget lịch thi (`HomeExamWidget`) bị chèn nhầm vào giao diện trang đăng nhập khi người dùng chưa đăng nhập nhưng truy cập đường dẫn gốc `/`.

## 🛠️ Chi tiết các thay đổi

- **`src/features/exam-helper/ui/home-exam-widget.ts`:**
  - Bổ sung hàm `mountHomeExamWidget(widget, root)` với các tầng kiểm tra nghiêm ngặt:
    - Chặn chèn nếu phát hiện view đăng nhập (`div.splash-container` / `#ctl00_inpUserName`).
    - Bắt buộc tìm thấy các container mục tiêu của Dashboard (`section.cttsv-overview-section` hoặc `div.cttsv-action-grid`) trước khi chèn.
    - Ngăn chặn chèn trùng lặp nếu widget đã tồn tại trong DOM.
- **`src/features/exam-helper/index.ts`:**
  - Cập nhật `runOnHomePage` sử dụng `mountHomeExamWidget` an toàn thay vì fallback `prepend` trực tiếp vào `.be-content`.
- **`src/features/exam-helper/__tests__/home-exam-widget.test.ts`:**
  - Thêm đầy đủ unit tests cho `mountHomeExamWidget` (chặn login view, kiểm tra target container, chống duplicate injection).
- **`docs/pages/home.md`:**
  - Cập nhật tài liệu mô tả chi tiết 2 trạng thái giao diện của đường dẫn gốc `/` (Dashboard View vs Login Splash View) và cảnh báo kỹ thuật cho các feature.

## 🧪 Kết quả kiểm tra chất lượng

- [x] `pnpm lint:fix` (0 errors)
- [x] `pnpm format:check` (All files match Prettier style)
- [x] `pnpm exec tsc --noEmit` (TypeScript type check passed)
- [x] `pnpm test` (120/120 tests passed)
- [x] `pnpm build:all` (Build userscript artifact successfully)